### PR TITLE
Allows 1–8 digits for Alabama

### DIFF
--- a/src/license-regex.js
+++ b/src/license-regex.js
@@ -11,8 +11,8 @@
 module.exports = {
   AL: [
     {
-      regex: /^[0-9]{1,7}$/i,
-      description: 'License must be 1-7 numbers',
+      regex: /^[0-9]{1,8}$/i,
+      description: 'License must be 1-8 numbers',
     },
   ],
   AK: [

--- a/test/data/test-licenses.js
+++ b/test/data/test-licenses.js
@@ -14,8 +14,8 @@ var oneLetterTwelveNumbers = ['A123456789012', 'A-123-456-789-012', 'A 123 456 7
 
 module.exports = {
   AL: {
-    validLicenses: sevenDigitLicense,
-    invalidLicenses: [].concat(invalidLicenses, nineNumbers, eightNumbers)
+    validLicenses: [].concat(sevenDigitLicense, eightNumbers),
+    invalidLicenses: [].concat(invalidLicenses, nineNumbers)
   },
   AK: {
     validLicenses: sevenDigitLicense,

--- a/test/is-valid-us-license.test.js
+++ b/test/is-valid-us-license.test.js
@@ -5,18 +5,23 @@ var testLicenses = require('./data/test-licenses')
 
 var sampleLicense = '1234567'
 
-var testLicense = function(state, validLicenses, invalidLicenses, lowercase = false) {
-  var validLicenses = validLicenses || []
-  var invalidLicenses = invalidLicenses || []
+var testLicense = function(
+  state, 
+  validLicenses = [], 
+  invalidLicenses = [], 
+  lowercase = false
+) {
   describe(state + ' State', function() {
-    _.forEach(validLicenses, function(license) {
-      it('isValidUSLicense returns for license' + license, function() {
-        expect(isValidUSLicense(lowercase ? license.toLowerCase() : license, state)).to.be.true
+    validLicenses.forEach(license => {
+      it('isValidUSLicense returns for license' + license, () => {
+        license = lowercase ? license.toLowerCase() : license;
+        expect(isValidUSLicense(license, state)).to.be.true
       });
     })
-    _.forEach(invalidLicenses, function(license) {
-      it('isValidUSLicense returns false for license' + license, function() {
-        expect(isValidUSLicense(lowercase ? license.toLowerCase() : license, state)).to.be.false
+    invalidLicenses.forEach(license => {
+      it('isValidUSLicense returns false for license' + license, () => {
+        license = lowercase ? license.toLowerCase() : license;
+        expect(isValidUSLicense(license, state)).to.be.false
       });
     })
   });


### PR DESCRIPTION
You can Ignore the test file *test/is-valid-us-license.test.js*
As this was just formatting.